### PR TITLE
don't use fixed version for install dependencies

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,3 +1,3 @@
-Jinja2==2.7.3
-PyYAML==3.11
-jsonschema==2.4.0
+Jinja2>=2.7.3
+PyYAML>=3.11
+jsonschema>=2.4.0


### PR DESCRIPTION
The dependencies listed are quite outdated, and apidoc works well with
newer versions — using minimal versions decreases the likelihood of
conflicts when requiring apidoc itself.